### PR TITLE
Fix the diagnostic and correction for non-ascii text

### DIFF
--- a/lua/languagetool/init.lua
+++ b/lua/languagetool/init.lua
@@ -128,9 +128,9 @@ end
 local function offset_to_position(offset, lines)
   local remaining = offset
   for line_idx, line in ipairs(lines) do
-    local line_len = #line
+    local line_len = vim.fn.strcharlen(line)
     if remaining <= line_len then
-      return line_idx - 1, remaining
+      return line_idx - 1, vim.fn.byteidx(line, remaining)
     end
     -- +1 for the newline character between lines
     remaining = remaining - line_len - 1


### PR DESCRIPTION
This PR fixes #2 by using the vim strcharlen instead of the lua length function, providing the actual number of character and not the number of bytes, as the languagetool offset speaks with characters offset.

And then it uses the vim function byteidx to get the byte offset remaining from the number of character, to tell neovim to highlight and fix the proper part of the text.
